### PR TITLE
Option "Extend" has been added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Type: `Object` Default: `undefined`
 
 Overwrite in manifest keys from object.
 
+#### extend
+Type: `Object` Default: `undefined`
+
+Extend manifest with object.
+
 ## Tests
 
 Grunt currently doesn't have a way to test tasks directly. You can test this task by running `grunt` and manually verify that it works.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mocha": "~1.7.4",
     "mkdirp": "~0.3.1",
     "rimraf": "~2.0.1",
-    "grunt-contrib-jshint": "~0.1.1"
+    "grunt-contrib-jshint": "~0.1.1",
+    "extend": "~1.3.0"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/tasks/chrome-manifest.js
+++ b/tasks/chrome-manifest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var path = require('path');
+var extend = require('extend');
 
 module.exports = function (grunt) {
 
@@ -117,6 +118,11 @@ module.exports = function (grunt) {
         for (var key in options.overwrite) {
           manifest[key] = options.overwrite[key];
         }
+      }
+
+      // Extend options
+      if(options.extend) {
+        extend(true, manifest, options.extend);
       }
 
       // Write updated manifest to destination.

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -39,5 +39,10 @@
         "scripts/contentscript-11.js"
       ]
     }
-  ]
+  ],
+  "test_extend": {
+    "overwrite": "overwrite",
+    "keep": "keep",
+    "arr": ["item 1", "item 2", "item 3"]
+  }
 }

--- a/test/test-chrome-manifest.js
+++ b/test/test-chrome-manifest.js
@@ -207,7 +207,10 @@ describe('Chrome manifest', function () {
       obj: {
         'option': 'option 1'
       },
-      arr: ['item 1', 'item 2', 'item 3']
+      arr: ['item 1', 'item 2', 'item 3'],
+      test_extend: {
+        overwrite: 'test'
+      }
     };
 
     grunt.config.init();
@@ -216,9 +219,32 @@ describe('Chrome manifest', function () {
     grunt.task.start();
 
     var manifest = grunt.file.readJSON(path.join(target.dest, 'manifest.json'));
+
     for (var key in target.options.overwrite) {
       assert.equal(JSON.stringify(manifest[key]), JSON.stringify(target.options.overwrite[key]));
     }
+    assert.equal(manifest['test_extend']['keep'], null);
   });
 
+  it('should extend options', function () {
+    var target = _.clone(targets.dist, true);
+    grunt.file.copy(path.join(__dirname, 'fixtures/manifest.json'), 'app/manifest.json');
+
+    target.options.extend = {
+      test_extend: {
+        overwrite: 'test'
+      }
+    };
+
+    grunt.config.init();
+    grunt.config('chromeManifest', {dist: target});
+    grunt.task.run('chromeManifest:dist');
+    grunt.task.start();
+
+    var manifest = grunt.file.readJSON(path.join(target.dest, 'manifest.json'));
+    var manifestOrigin = grunt.file.readJSON(path.join(target.src, 'manifest.json'));
+
+    assert.equal(manifest['test_extend']['overwrite'], target.options.extend['test_extend']['overwrite']);
+    assert.equal(manifest['test_extend']['keep'], manifestOrigin['test_extend']['keep']);
+  });
 });


### PR DESCRIPTION
Useful when you are going to extend some parameters of object, but some fields keep without changing. For example manifest:
{
  "app": {
    "override": "override",
    "keep": "keep"
  }
}
and you want to override field "override" but keep field "keep" without changes.
Now with only option "Override" you only can override whole section "app".
But with new option "Extend" you can extend this object with keeping some fields.

Tests also has been added.