### PR TITLE
Give developer a chance to keep their background scripts intact

### DIFF
--- a/tasks/chrome-manifest.js
+++ b/tasks/chrome-manifest.js
@@ -61,9 +61,17 @@ module.exports = function (grunt) {
 
           // set script from scripts in target
           background.scripts = [options.background.target];
+
         } else {
-          // remove background.scripts if target is not given
-          delete background.scripts;
+
+          // only apply exclude rules if target is not given
+          _.each(background.scripts, function (script) {
+            if (_.indexOf(options.background.exclude, script) >= 0) {
+              var expos = background.scripts.indexOf(script);
+              if(expos >= 0) background.scripts.splice(expos, 1);
+            }
+          });
+
         }
       }
 


### PR DESCRIPTION
Hi, 
I recently started using yeoman/generator-chrome-extension and ran into a small issue. Namely wanting to include jquery both in page action and background page but since concat+uglify is forced on the background script I ended up with two copies of jquery which wasn't optimal.

Sure background scripts could be added to Gruntfile's copy-task (excluding chromereload.js), but if no background.target is specified for grunt-chrome-manifest the manifest declaration is left empty.
What I propose is to only apply exclude rules to background scripts if no target is specified.
