### PR TITLE
Allows overwrite to descend down multiple levels.

### DIFF
--- a/tasks/chrome-manifest.js
+++ b/tasks/chrome-manifest.js
@@ -6,6 +6,28 @@ module.exports = function (grunt) {
 
   var _ = grunt.util._;
 
+  /**
+   * Overwrites all properties in dest with values from src.
+   */
+  function overwrite(dest, src, breadcrumbs) {
+    if (!breadcrumbs) {
+      breadcrumbs = [];
+    }
+    for (var key in src) {
+      if (!(key in dest) || (typeof src[key] !== 'object')) {
+        dest[key] = src[key];
+      } else {
+        if (typeof dest[key] !== 'object') {
+          grunt.fail.warn('attempt to overwrite ' + (typeof dest[key]) + ' with object: ' + breadcrumbs.join('.'));
+        } else {
+          breadcrumbs.push(key);
+          overwrite(dest[key], src[key], breadcrumbs);
+          breadcrumbs.pop();
+        }
+      }
+    }
+  }
+
   grunt.registerMultiTask('chromeManifest', '', function () {
     var options = this.options({
       buildnumber: undefined,
@@ -119,9 +141,7 @@ module.exports = function (grunt) {
 
       // Overwrite options
       if (options.overwrite) {
-        for (var key in options.overwrite) {
-          manifest[key] = options.overwrite[key];
-        }
+        overwrite(manifest, options.overwrite);
       }
 
       //remove fields

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -2,6 +2,10 @@
   "name": "Chrome Manifest",
   "version": "0.0.1",
   "manifest_version": 2,
+  "icons": {
+    "32": "images/icon-32.png",
+    "128": "images/icon-128.png"
+  },
   "background": {
     "scripts": [
       "scripts/willbe-remove-only-for-debug.js",

--- a/test/test-chrome-manifest.js
+++ b/test/test-chrome-manifest.js
@@ -35,6 +35,22 @@ describe('Chrome manifest', function () {
 
   before(directory('temp'));
 
+  /**
+   * Assert that all properties in expected also appear, with the same values,
+   * in actual.
+   */
+  function assertContainsAll(actual, expected) {
+    for (var key in expected) {
+      var type = typeof expected[key];
+      assert.equal(type, typeof actual[key], 'type of value for key ' + key + ' mismatch');
+      if (type === 'object') {
+        assertContainsAll(actual[key], expected[key]);
+      } else {
+        assert.equal(expected[key], actual[key], 'property ' + key + ' must match');
+      }
+    }
+  }
+
   var targets = {
     dist: {
       options: {
@@ -205,7 +221,15 @@ describe('Chrome manifest', function () {
     target.options.overwrite = {
       test: 'test',
       obj: {
-        'option': 'option 1'
+        'option': 'option 1',
+      },
+      icons: {
+        '128': 'images/prod-128.png'
+      },
+      'deep': {
+        'branch': {
+          'leaf': 'yes'
+        }
       },
       arr: ['item 1', 'item 2', 'item 3']
     };
@@ -216,9 +240,8 @@ describe('Chrome manifest', function () {
     grunt.task.start();
 
     var manifest = grunt.file.readJSON(path.join(target.dest, 'manifest.json'));
-    for (var key in target.options.overwrite) {
-      assert.equal(JSON.stringify(manifest[key]), JSON.stringify(target.options.overwrite[key]));
-    }
+    assertContainsAll(manifest, target.options.overwrite);
+    assert.equal('images/icon-32.png', manifest.icons['32']);
   });
 
   it('should remove fields', function () {


### PR DESCRIPTION
This change allows users to overwrite nested manifest properties. Currently, only first-level properties can be overwritten.

My particular use case is prod vs. staging using different oauth2 client IDs and icons.

I did not add a test that the task fails when the overwrite is hard to reconcile, but it's very hard to imagine it happening in practice unless it's a typo or other syntax mistake.
